### PR TITLE
fix for ember-bootstrap skel url

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -62,7 +62,7 @@
     },
     {
       "name":"ember-bootstrap",
-      "url":"git://github.com/anachron/mimosa-emberboots.git",
+      "url":"git://github.com/Anachron/mimosa-emberboots.git",
       "description":"Mimosa-Skeleton for EmberJS, Bootstrap, Font-Awesome, Jade, Emblem, Less and Express-Apps.",
       "author":"Anachron",
       "keywords":["mimosa", "module", "coffeescript", "emberjs", "Font-Awesome", "Jade", "Emblem", "Less", "Express"],


### PR DESCRIPTION
git (at least on windows) can't clone, if the capitalization in the url for a repo isn't right. So mimosa skel:new ember-bootstrap test fails on my machine.
