### PR TITLE
Point the Durandal skeleton back to the original / official BlueSpire def

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -302,7 +302,7 @@
     },
     {
       "name":"durandal",
-      "url":"https://github.com/dbashford/Durandal-Mimosa-Node-Skeleton",
+      "url":"https://github.com/BlueSpire/Durandal-Mimosa-Skeleton",
       "description":"A Durandal skeleton project with a basic navigation-style architecture pre-configured.",
       "author":"BlueSpire",
       "keywords":["durandal", "knockout", "jquery", "sammyjs", "bootstrap", "mvvm","mvp","mvc","navigation","router","requirejs"],


### PR DESCRIPTION
BlueSpire has updated Durandal. Because this skeleton switched to a fork, it missed the update.

There are other Durandal skeletons, including one explicitly pointing to the durandal-node-skeleton. So let's put the default durandal skeleton back  to the official.
